### PR TITLE
Apparently not needed to parse out list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -16,5 +16,4 @@ function sort_versions() {
 
 versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//;s/v//' | sort_versions)
 
-# shellcheck disable=SC2086
-echo $versions
+echo "${versions}"

--- a/bin/list-all
+++ b/bin/list-all
@@ -17,4 +17,4 @@ function sort_versions() {
 versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//;s/v//' | sort_versions)
 
 # shellcheck disable=SC2086
-echo $versions | tr " " "\n"
+echo $versions


### PR DESCRIPTION
- Fixing `list-all` which was only displaying a single version. Figured out that asdf will take the output and parse it natively.